### PR TITLE
add ASC in index creation (for YugabyteDB to avoid hash sharding)

### DIFF
--- a/main.sql
+++ b/main.sql
@@ -4,7 +4,7 @@ CREATE TABLE tbl_jsonb (data jsonb);
 
 
 CREATE TABLE tbl_btree_idx_score (data jsonb);
-CREATE INDEX ON tbl_btree_idx_score (CAST(data->>'score' AS FLOAT));
+CREATE INDEX ON tbl_btree_idx_score (CAST(data->>'score' AS FLOAT) ASC);
 
 CREATE TABLE tbl_gin_idx (data jsonb);
 CREATE INDEX ON tbl_gin_idx USING GIN (data);


### PR DESCRIPTION
This is harmless in PostgreSQL as the default is `ASC` but useful in YugabyteDB where the default is `HASH` for hash sharding. As there's a range query on this column, the index must be range sharded if anyone wants to run this on YugabyteDB (which I did... blog post about it soon)